### PR TITLE
Update requirements to fix (?) PS retrieval error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 psutil>=5.7.0
 pyside2==5.15.2
-urllib3==1.26.5
-furl==2.1.0
-certifi==2020.6.20
+urllib3==1.26.7
+furl==2.1.3
+certifi==2021.10.8
 numpy>=1.19.0
-requests~=2.25.1
-beautifulsoup4~=4.9.1
-jsonschema~=3.2.0
+requests==2.26.0
+beautifulsoup4==4.10.0
+jsonschema==4.1.0
 rarfile~=4.0
 nodegraphqt>=0.1.7

--- a/zoia_lib/UI/resources/dark.css
+++ b/zoia_lib/UI/resources/dark.css
@@ -17,7 +17,7 @@ QMenu::separator
 }
 
 QMenu::item {
-    background-color: #5e616e;
+    background-color: #585b67;
     color: #FFF
 }
 


### PR DESCRIPTION
Currently attempting to determine why Windows users seem unable to access PS. Running from the latest commit on master with a requirements bump removed the issue. Hopefully this can be merged and a new exe can be created.