### PR TITLE
Fix patch retrieval

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 psutil>=5.7.0
-pyside2==5.15.2
-urllib3==1.26.7
+pyside2==5.15.2.1
+urllib3==1.26.8
 furl==2.1.3
 certifi==2021.10.8
 numpy>=1.19.0
-requests==2.26.0
+requests==2.27.1
 beautifulsoup4==4.10.0
-jsonschema==4.1.0
+jsonschema==4.4.0
 rarfile~=4.0
 nodegraphqt>=0.1.7

--- a/zoia_lib/backend/api.py
+++ b/zoia_lib/backend/api.py
@@ -248,4 +248,4 @@ class PatchStorage:
         )
 
         # Return the total minus the number of questions found.
-        return int(zoia[:3]) - len(soup_ques.find_all(class_="card"))
+        return int(zoia.split("<")[0]) - len(soup_ques.find_all(class_="card"))


### PR DESCRIPTION
- Whoops, we were parsing on an index that only worked for a patch count of less than 1000. This should correct the issue unless there are ever any significant updates to the web design of the PatchStorage website.
- Also bumped the package dependencies to their latest versions.