### PR TITLE
fix: category and tag sort order

### DIFF
--- a/zoia_lib/UI/ZOIALibrarian_main.py
+++ b/zoia_lib/UI/ZOIALibrarian_main.py
@@ -1091,10 +1091,10 @@ class ZOIALibrarianMain(QMainWindow):
                 "actionSort_by_author_Z_A": (2, True),
                 "actionSort_by_rating_high_low": (8, True),
                 "actionSort_by_rating_low_high": (8, False),
-                "actionSort_by_category_high_low": (9, False),
-                "actionSort_by_category_low_high": (9, True),
-                "actionSort_by_tag_high_low": (10, False),
-                "actionSort_by_tag_low_high": (10, True),
+                "actionSort_by_category_high_low": (9, True),
+                "actionSort_by_category_low_high": (9, False),
+                "actionSort_by_tag_high_low": (10, True),
+                "actionSort_by_tag_low_high": (10, False),
             }[self.sender().objectName()]
             self.prev_sort = curr_sort
         except KeyError:


### PR DESCRIPTION
Fixes bug, which is that the category and tag sorting is reversed.

The fix is to set reverse=True for high-low, and reverse=False for low-high.

This makes the reverse assignment consistent for all high-low/low-high sort actions.